### PR TITLE
RAC-6604 Fix the bug of gradle can't build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,15 +30,16 @@ buildscript {
     	springCloudVersion = 'Camden.SR5'
 	}
    repositories {
-    mavenLocal()
-	maven {url "${artifactory_contextUrl}/libs-release"}
-	maven {url "https://plugins.gradle.org/m2/"} 
-  }
+       mavenLocal()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
   dependencies {
   	classpath "io.spring.gradle:dependency-management-plugin:1.0.2.RELEASE"
     classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
 	classpath(group: 'com.netflix.nebula', name: 'gradle-ospackage-plugin', version: '4.4.0' )
-	classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.2.1"
+	classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.1"
 	classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1"
 	//classpath 'com.netflix.nebula:gradle-lint-plugin:latest.release'
   }
@@ -79,8 +80,10 @@ jar {
 repositories {
 	mavenLocal()
 	maven {
-		url "${artifactory_contextUrl}/libs-release"
-	}
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+        url "https://oss.sonatype.org/content/repositories/releases"
+        url "https://repo.maven.apache.org/maven2"
+    }
 }
 
 
@@ -99,7 +102,7 @@ dependencies {
 	compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.3'
 	compile group: "io.springfox", name: "springfox-swagger2", version: "2.6.1"
 	compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.6.1'
-        compile group: 'org.samba.jcifs', name: 'jcifs', version: '1.3.15'
+    compile group: 'org.samba.jcifs', name: 'jcifs', version: '1.3.14-kohsuke-1'
 
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 }


### PR DESCRIPTION
**Background**
It's found that all the smi-service-xxx repo can't be built with gradle. From the error log, the old version of sonarqube cannot work. So, the version of sonarqube needs to be upgraded. Besides, the artifactory_contextUrl “https://gtie-artifactory.us.dell.com/artifactory” defined in the file “gradle.properties” isn't used any more. It's replaced with "https://plugins.gradle.org/".

**Reviewers**
@nortonluo @AlaricChan @lanchongyizu